### PR TITLE
Fixed vision bug

### DIFF
--- a/src/main/java/frc/robot/commands/drive/DriveCommandBase.java
+++ b/src/main/java/frc/robot/commands/drive/DriveCommandBase.java
@@ -41,7 +41,7 @@ public abstract class DriveCommandBase extends Command {
     swerveDrive.addPoseEstimatorSwerveMeasurement();
     vision.setHeadingInfo(
         swerveDrive.getPose().getRotation().getDegrees(), swerveDrive.getGyroRate());
-    calculatePoseFromLimelight(Limelight.SHOOTER);
+    calculatePoseFromLimelight(Limelight.BACK);
     calculatePoseFromLimelight(Limelight.FRONT_LEFT);
     calculatePoseFromLimelight(Limelight.FRONT_RIGHT);
   }

--- a/src/main/java/frc/robot/subsystems/vision/PhysicalVision.java
+++ b/src/main/java/frc/robot/subsystems/vision/PhysicalVision.java
@@ -25,8 +25,7 @@ public class PhysicalVision implements VisionInterface {
   private final ThreadManager threadManager = new ThreadManager(Limelight.values().length);
 
   /**
-   * The pose estimates from the limelights in the following order {shooterLimelight,
-   * frontLeftLimelight, frontRightLimelight}
+   * The pose estimates from the limelights in the following order (BACK, FRONT_LEFT, FRONT_RIGHT)
    */
   private MegatagPoseEstimate[] limelightEstimates =
       new MegatagPoseEstimate[] {
@@ -70,7 +69,7 @@ public class PhysicalVision implements VisionInterface {
   /**
    * Checks if the specified limelight can fully see one or more April Tag.
    *
-   * @param limelight a limelight (SHOOTER, FRONT_LEFT, FRONT_RIGHT).
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    * @return true if the limelight can fully see one or more April Tag
    */
   @Override
@@ -98,7 +97,7 @@ public class PhysicalVision implements VisionInterface {
    * Gets the JSON dump from the specified limelight and puts it into a PoseEstimate object, which
    * is then placed into its corresponding spot in the limelightEstimates array.
    *
-   * @param limelight a limelight (SHOOTER, FRONT_LEFT, FRONT_RIGHT).
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    */
   public MegatagPoseEstimate enabledPoseUpdate(Limelight limelight) {
     PoseEstimate megatag1Estimate = getMegaTag1PoseEstimate(limelight);
@@ -127,7 +126,7 @@ public class PhysicalVision implements VisionInterface {
    * If the robot is not enabled, update the pose using MegaTag1 and after it is enabled, run {@link
    * #enabledPoseUpdate(int)}
    *
-   * @param limelight a limelight (SHOOTER, FRONT_LEFT, FRONT_RIGHT).
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    */
   public void updatePoseEstimate(Limelight limelight, VisionInputs inputs) {
     synchronized (inputs) {
@@ -141,7 +140,7 @@ public class PhysicalVision implements VisionInterface {
   /**
    * Checks if there is a large discrepancy between the MegaTag1 and MegaTag2 estimates.
    *
-   * @param limelight a limelight (SHOOTER, FRONT_LEFT, FRONT_RIGHT).
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    * @return true if the discrepancy is larger than the defined threshold, false otherwise
    */
   public boolean isLargeDiscrepancyBetweenMegaTag1And2(
@@ -161,7 +160,7 @@ public class PhysicalVision implements VisionInterface {
    * Gets the MegaTag1 pose of the robot calculated by specified limelight via any April Tags it
    * sees
    *
-   * @param limelight a limelight (SHOOTER, FRONT_LEFT, FRONT_RIGHT).
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    * @return the MegaTag1 pose of the robot, if the limelight can't see any April Tags, it will
    *     return 0 for x, y, and theta
    */
@@ -173,7 +172,7 @@ public class PhysicalVision implements VisionInterface {
    * Gets the MegaTag2 pose of the robot calculated by specified limelight via any April Tags it
    * sees
    *
-   * @param limelight a limelight (SHOOTER, FRONT_LEFT, FRONT_RIGHT).
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    * @return the MegaTag2 pose of the robot, if the limelight can't see any April Tags, it will
    *     return 0 for x, y, and theta
    */
@@ -184,7 +183,7 @@ public class PhysicalVision implements VisionInterface {
   /**
    * Checks if the MT1 and MT2 pose estimate exists and whether it is within the field
    *
-   * @param limelight a limelight (SHOOTER, FRONT_LEFT, FRONT_RIGHT).
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    * @return true if the pose estimate exists within the field and the pose estimate is not null
    */
   public boolean isValidPoseEstimate(Limelight limelight, PoseEstimate mt1, PoseEstimate mt2) {
@@ -214,7 +213,7 @@ public class PhysicalVision implements VisionInterface {
   /**
    * Gets the pose of the robot calculated by specified limelight via any April Tags it sees
    *
-   * @param limelight a limelight (SHOOTER, FRONT_LEFT, FRONT_RIGHT).
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    * @return the pose of the robot, if the limelight can't see any April Tags, it will return 0 for
    *     x, y, and theta
    */
@@ -268,7 +267,7 @@ public class PhysicalVision implements VisionInterface {
   /**
    * Gets the average distance between the specified limelight and the April Tags it sees
    *
-   * @param limelight a limelight (SHOOTER, FRONT_LEFT, FRONT_RIGHT).
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    * @return the average distance between the robot and the April Tag(s) in meters
    */
   @Override

--- a/src/main/java/frc/robot/subsystems/vision/PhysicalVision.java
+++ b/src/main/java/frc/robot/subsystems/vision/PhysicalVision.java
@@ -66,31 +66,16 @@ public class PhysicalVision implements VisionInterface {
     }
   }
 
-  /**
-   * Checks if the specified limelight can fully see one or more April Tag.
-   *
-   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
-   * @return true if the limelight can fully see one or more April Tag
-   */
   @Override
   public boolean canSeeAprilTags(Limelight limelight) {
-    // First checks if it can see an april tag, then checks if it is fully in frame
-    // Different Limelights have different FOVs
-    if (getNumberOfAprilTags(limelight) > VisionConstants.MIN_APRIL_TAG_ID
-        && getNumberOfAprilTags(limelight) <= VisionConstants.MAX_APRIL_TAG_ID) {
-      if (limelight.getName().equals(Limelight.BACK.getName())) {
-        return Math.abs(LimelightHelpers.getTX(limelight.getName()))
-            <= VisionConstants.LL3G_FOV_MARGIN_OF_ERROR;
-      } else {
-        // return false;
-        return Math.abs(LimelightHelpers.getTX(limelight.getName()))
-            <= VisionConstants.LL3_FOV_MARGIN_OF_ERROR;
-      }
+    // First checks if it can see an april tag, then checks if it is fully in frame as
+    // the limelight can see an april tag but not have it fully in frame, leading to
+    // inaccurate pose estimates
+    if (getNumberOfAprilTags(limelight) > 0) {
+      return Math.abs(LimelightHelpers.getTX(limelight.getName()))
+            <= limelight.getAccurateFOV();
     }
-    // return latestInputs.get().limelightSeesAprilTags[limelight.getId()] = false;
-    // return  LimelightHelpers.getTV(limelight.getName());
     return false;
-    // latestInputs.get().limelightSeesAprilTags[limelight.getId()] =
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/vision/PhysicalVision.java
+++ b/src/main/java/frc/robot/subsystems/vision/PhysicalVision.java
@@ -79,7 +79,7 @@ public class PhysicalVision implements VisionInterface {
     // Different Limelights have different FOVs
     if (getNumberOfAprilTags(limelight) > VisionConstants.MIN_APRIL_TAG_ID
         && getNumberOfAprilTags(limelight) <= VisionConstants.MAX_APRIL_TAG_ID) {
-      if (limelight.getName().equals(Limelight.SHOOTER.getName())) {
+      if (limelight.getName().equals(Limelight.BACK.getName())) {
         return Math.abs(LimelightHelpers.getTX(limelight.getName()))
             <= VisionConstants.LL3G_FOV_MARGIN_OF_ERROR;
       } else {
@@ -336,7 +336,7 @@ public class PhysicalVision implements VisionInterface {
           latestInputs.set(inputs);
 
           limelightThreads.computeIfPresent(limelight, (key, value) -> latestInputs);
-          // // Handle threading for Limelight (start or stop threads if needed)
+          // Handle threading for Limelight (start or stop threads if needed)
           // Check if this Limelight thread exists in limelightThreads
           if (limelightThreads.get(limelight) != null) {
             // Update thread inputs or restart the thread if needed
@@ -350,7 +350,7 @@ public class PhysicalVision implements VisionInterface {
             lastSeenPose = getMegaTag1PoseEstimate(limelight).pose;
           }
         } else {
-          // // Retrieve the AtomicReference for the given limelight number
+          // Retrieve the AtomicReference for the given limelight number
           AtomicReference<VisionInputs> isThreadRunning =
               limelightThreads.getOrDefault(limelight, latestInputs);
           // Only stop the thread if it's currently running

--- a/src/main/java/frc/robot/subsystems/vision/SimulatedVision.java
+++ b/src/main/java/frc/robot/subsystems/vision/SimulatedVision.java
@@ -58,7 +58,7 @@ public class SimulatedVision extends PhysicalVision {
     // targets.
     // Instance variables
     shooterCameraSim =
-        new PhotonCameraSim(getSimulationCamera(Limelight.SHOOTER), cameraProperties);
+        new PhotonCameraSim(getSimulationCamera(Limelight.BACK), cameraProperties);
     frontLeftCameraSim =
         new PhotonCameraSim(getSimulationCamera(Limelight.FRONT_LEFT), cameraProperties);
     frontRightCameraSim =
@@ -174,7 +174,7 @@ public class SimulatedVision extends PhysicalVision {
    */
   private PhotonCamera getSimulationCamera(Limelight limelight) {
     return switch (limelight) {
-      case SHOOTER -> VisionConstants.SHOOTER_CAMERA;
+      case BACK -> VisionConstants.SHOOTER_CAMERA;
       case FRONT_LEFT -> VisionConstants.FRONT_LEFT_CAMERA;
       case FRONT_RIGHT -> VisionConstants.FRONT_RIGHT_CAMERA;
       default -> throw new IllegalArgumentException("Invalid limelight camera " + limelight);
@@ -189,7 +189,7 @@ public class SimulatedVision extends PhysicalVision {
    */
   private NetworkTable getLimelightTable(Limelight limelight) {
     return switch (limelight) {
-      case SHOOTER -> LimelightHelpers.getLimelightNTTable(Limelight.SHOOTER.getName());
+      case BACK -> LimelightHelpers.getLimelightNTTable(Limelight.BACK.getName());
       case FRONT_LEFT -> LimelightHelpers.getLimelightNTTable(Limelight.FRONT_LEFT.getName());
       case FRONT_RIGHT -> LimelightHelpers.getLimelightNTTable(Limelight.FRONT_RIGHT.getName());
       default -> throw new IllegalArgumentException("Invalid limelight " + limelight);

--- a/src/main/java/frc/robot/subsystems/vision/SimulatedVision.java
+++ b/src/main/java/frc/robot/subsystems/vision/SimulatedVision.java
@@ -65,7 +65,7 @@ public class SimulatedVision extends PhysicalVision {
         new PhotonCameraSim(getSimulationCamera(Limelight.FRONT_RIGHT), cameraProperties);
 
     visionSim.addCamera(
-        shooterCameraSim, VisionConstants.SHOOTER_TRANSFORM); // check inverse things
+        shooterCameraSim, VisionConstants.BACK_TRANSFORM); // check inverse things
     visionSim.addCamera(frontLeftCameraSim, VisionConstants.FRONT_LEFT_TRANSFORM);
     visionSim.addCamera(frontRightCameraSim, VisionConstants.FRONT_RIGHT_TRANSFORM);
 
@@ -174,7 +174,7 @@ public class SimulatedVision extends PhysicalVision {
    */
   private PhotonCamera getSimulationCamera(Limelight limelight) {
     return switch (limelight) {
-      case BACK -> VisionConstants.SHOOTER_CAMERA;
+      case BACK -> VisionConstants.BACK_CAMERA;
       case FRONT_LEFT -> VisionConstants.FRONT_LEFT_CAMERA;
       case FRONT_RIGHT -> VisionConstants.FRONT_RIGHT_CAMERA;
       default -> throw new IllegalArgumentException("Invalid limelight camera " + limelight);

--- a/src/main/java/frc/robot/subsystems/vision/ThreadManager.java
+++ b/src/main/java/frc/robot/subsystems/vision/ThreadManager.java
@@ -8,15 +8,33 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Manages threads for various tasks within the robot's vision system.
+ * Provides methods to start, stop, and manage threads efficiently while preventing excessive updates.
+ * 
+ * @author Ishan
+ */
 public class ThreadManager {
+
   private final ExecutorService executorService;
   private final Map<String, Future<?>> threadFutures = new ConcurrentHashMap<>();
 
+  /**
+   * Creates a ThreadManager with a fixed number of threads.
+   *
+   * @param maxThreads the maximum number of threads that can run simultaneously.
+   */
   public ThreadManager(int maxThreads) {
     executorService = Executors.newFixedThreadPool(maxThreads);
   }
 
-  // Start a thread for a specific task
+  /**
+   * Starts a new thread to run a specific task. If a thread with the given name is already running,
+   * the method will print an error message and do nothing.
+   *
+   * @param threadName the name of the thread to start.
+   * @param task the task to run on the thread, this can be a function.
+   */
   public void startThread(String threadName, Runnable task) {
     if (threadFutures.containsKey(threadName)) {
       System.err.println("Thread " + threadName + " is already running.");
@@ -36,7 +54,11 @@ public class ThreadManager {
     threadFutures.put(threadName, future);
   }
 
-  // Stop a specific thread
+  /**
+   * Stops a specific thread by its name. If the thread is not running, an error message is printed.
+   *
+   * @param threadName the name of the thread to stop.
+   */
   public void stopThread(String threadName) {
     Future<?> future = threadFutures.get(threadName);
     if (future != null) {
@@ -47,7 +69,14 @@ public class ThreadManager {
     }
   }
 
-  // Submit a vision input task
+  /**
+   * Starts a vision-related task that periodically updates vision inputs.
+   * This method creates a thread that repeatedly executes the provided task until interrupted.
+   *
+   * @param threadName the name of the thread to start.
+   * @param inputs the vision inputs to be updated.
+   * @param visionTask the task that updates vision inputs.
+   */
   public void startVisionInputTask(String threadName, VisionInputs inputs, Runnable visionTask) {
     startThread(
         threadName,
@@ -63,7 +92,10 @@ public class ThreadManager {
         });
   }
 
-  // Shut down all threads
+  /**
+   * Shuts down all threads managed by this instance. Attempts a graceful shutdown, then forces it
+   * if necessary.
+   */
   public void shutdownAllThreads() {
     threadFutures.values().forEach(future -> future.cancel(true));
     threadFutures.clear();

--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -10,16 +10,18 @@ import org.photonvision.PhotonCamera;
 
 public final class VisionConstants {
   public enum Limelight {
-    BACK(0, VisionConstants.BACK_LIMELIGHT_NAME),
-    FRONT_LEFT(1, VisionConstants.FRONT_LEFT_LIMELIGHT_NAME),
-    FRONT_RIGHT(2, VisionConstants.FRONT_RIGHT_LIMELIGHT_NAME);
+    BACK(0, VisionConstants.BACK_LIMELIGHT_NAME, LL3G_FOV_MARGIN_OF_ERROR), // We have one LL3G
+    FRONT_LEFT(1, VisionConstants.FRONT_LEFT_LIMELIGHT_NAME, LL3_FOV_MARGIN_OF_ERROR),
+    FRONT_RIGHT(2, VisionConstants.FRONT_RIGHT_LIMELIGHT_NAME, LL3_FOV_MARGIN_OF_ERROR);
 
     private final int id;
     private final String name;
+    private final double accurateFOV;
 
-    Limelight(int id, String name) {
+    Limelight(int id, String name, double accurateFOV) {
       this.id = id;
       this.name = name;
+      this.accurateFOV = accurateFOV;
     }
 
     public int getId() {
@@ -28,6 +30,10 @@ public final class VisionConstants {
 
     public String getName() {
       return name;
+    }
+
+    public double getAccurateFOV() {
+      return accurateFOV;
     }
 
     public static Limelight fromId(int id) {
@@ -40,7 +46,7 @@ public final class VisionConstants {
     }
   }
 
-  public static final Transform3d SHOOTER_TRANSFORM =
+  public static final Transform3d BACK_TRANSFORM =
       new Transform3d(
           new Translation3d(-0.3119324724, 0.0, 0.1865472012), new Rotation3d(0.0, 35, 180.0));
   public static final Transform3d FRONT_LEFT_TRANSFORM =
@@ -51,7 +57,7 @@ public final class VisionConstants {
       new Transform3d(
           new Translation3d(0.2816630892, 0.2724405524, 0.232156), new Rotation3d(0.0, 25, 35));
 
-  public static final PhotonCamera SHOOTER_CAMERA = new PhotonCamera(Limelight.BACK.getName());
+  public static final PhotonCamera BACK_CAMERA = new PhotonCamera(Limelight.BACK.getName());
   public static final PhotonCamera FRONT_LEFT_CAMERA =
       new PhotonCamera(Limelight.FRONT_LEFT.getName());
   public static final PhotonCamera FRONT_RIGHT_CAMERA =
@@ -78,14 +84,14 @@ public final class VisionConstants {
   public static final double MEGA_TAG_ROTATION_DISCREPANCY_THREASHOLD = 45;
 
   public static final String BACK_LIMELIGHT_NAME = "limelight-shooter";
-  public static final int SHOOTER_LIMELIGHT_NUMBER = 0;
+  public static final int BACK_LIMELIGHT_NUMBER = 0;
   public static final String FRONT_LEFT_LIMELIGHT_NAME = "limelight-left";
   public static final int FRONT_LEFT_LIMELIGHT_NUMBER = 1;
   public static final String FRONT_RIGHT_LIMELIGHT_NAME = "limelight-right";
   public static final int FRONT_RIGHT_LIMELIGHT_NUMBER = 2;
 
   public static final int MIN_APRIL_TAG_ID = 1;
-  public static final int MAX_APRIL_TAG_ID = 16;
+  public static final int MAX_APRIL_TAG_ID = 22;
 
   public static final double[][] ONE_APRIL_TAG_LOOKUP_TABLE = {
     // {distance in meters, x std deviation, y std deviation, r (in degrees) std deviation}

--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -10,7 +10,7 @@ import org.photonvision.PhotonCamera;
 
 public final class VisionConstants {
   public enum Limelight {
-    SHOOTER(0, VisionConstants.SHOOTER_LIMELIGHT_NAME),
+    BACK(0, VisionConstants.BACK_LIMELIGHT_NAME),
     FRONT_LEFT(1, VisionConstants.FRONT_LEFT_LIMELIGHT_NAME),
     FRONT_RIGHT(2, VisionConstants.FRONT_RIGHT_LIMELIGHT_NAME);
 
@@ -32,7 +32,7 @@ public final class VisionConstants {
 
     public static Limelight fromId(int id) {
       return switch (id) {
-        case 0 -> SHOOTER;
+        case 0 -> BACK;
         case 1 -> FRONT_LEFT;
         case 2 -> FRONT_RIGHT;
         default -> throw new IllegalArgumentException("Invalid Limelight ID: " + id);
@@ -51,7 +51,7 @@ public final class VisionConstants {
       new Transform3d(
           new Translation3d(0.2816630892, 0.2724405524, 0.232156), new Rotation3d(0.0, 25, 35));
 
-  public static final PhotonCamera SHOOTER_CAMERA = new PhotonCamera(Limelight.SHOOTER.getName());
+  public static final PhotonCamera SHOOTER_CAMERA = new PhotonCamera(Limelight.BACK.getName());
   public static final PhotonCamera FRONT_LEFT_CAMERA =
       new PhotonCamera(Limelight.FRONT_LEFT.getName());
   public static final PhotonCamera FRONT_RIGHT_CAMERA =
@@ -77,7 +77,7 @@ public final class VisionConstants {
   public static final double MEGA_TAG_TRANSLATION_DISCREPANCY_THRESHOLD = 0.5; // TODO: tune
   public static final double MEGA_TAG_ROTATION_DISCREPANCY_THREASHOLD = 45;
 
-  public static final String SHOOTER_LIMELIGHT_NAME = "limelight-shooter";
+  public static final String BACK_LIMELIGHT_NAME = "limelight-shooter";
   public static final int SHOOTER_LIMELIGHT_NUMBER = 0;
   public static final String FRONT_LEFT_LIMELIGHT_NAME = "limelight-left";
   public static final int FRONT_LEFT_LIMELIGHT_NUMBER = 1;

--- a/src/main/java/frc/robot/subsystems/vision/VisionInterface.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionInterface.java
@@ -79,8 +79,10 @@ public interface VisionInterface {
   }
 
   /**
-   * @param limelight The Limelight to retrieve the target data from
-   * @return Whether the Limelight can see any targets, and if it is within its field of view
+   * Checks if the specified limelight can fully see one or more April Tag.
+   *
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
+   * @return true if the Limelight can see any april tags, and if it is within its field of view
    */
   default boolean canSeeAprilTags(Limelight limelight) {
     return false;

--- a/src/main/java/frc/robot/subsystems/vision/VisionInterface.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionInterface.java
@@ -6,21 +6,53 @@ import frc.robot.subsystems.vision.VisionConstants.Limelight;
 import org.littletonrobotics.junction.AutoLog;
 
 public interface VisionInterface {
+
+  /**
+   * This class is used to store the inputs for the vision subsystem. Each of its fields that are 
+   * arrays have a length equal to the number of Limelights on the robot. Each index of the arrays
+   * corresponds to a different Limelight (0 is back, 1 is front left, 2 is front right). 
+   */
   @AutoLog
   class VisionInputs {
+    /**
+     * This array stores whether each Limelight is connected to the robot.
+     */
     public boolean[] isLimelightConnected = new boolean[Limelight.values().length];
-
+    /**
+     * This array stores MegatagPoseEstimates for each Limelight.
+     */
     public MegatagPoseEstimate[] limelightMegatagPoses =
         new MegatagPoseEstimate[Limelight.values().length];
+    /**
+     * This array stores the latencies in seconds of each Limelight.
+     */
     public double[] limelightLatencies = new double[Limelight.values().length];
+    /**
+     * This array stores the number of april tags each Limelight sees.
+     */
     public int[] limelightTargets = new int[Limelight.values().length];
+    /**
+     * This array stores whether each Limelight sees any April Tags.
+     */
     public boolean[] limelightSeesAprilTags = new boolean[Limelight.values().length];
-
+    /**
+     * This array stores the poses calculated from the April Tags seen by each Limelight.
+     */
     public Pose2d[] limelightCalculatedPoses = new Pose2d[Limelight.values().length];
-    public Pose2d limelightLastSeenPose = new Pose2d();
+    /**
+     * This array stores the distances in meters to the April Tags seen by each Limelight.
+     */
     public double[] limelightAprilTagDistances = new double[Limelight.values().length];
-
+    /**
+     * This array stores the timestamps in seconds of the data from each Limelight.
+     */
     public double[] limelightTimestamps = new double[Limelight.values().length];
+
+    /**
+     * This stores the last seen pose of any Limelight that most recently saw a target.
+     * This is primarily used if a driver wants to reset the robot's pose to what the limelights are seeing.
+     */
+    public Pose2d limelightLastSeenPose = new Pose2d();
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/vision/VisionInterface.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionInterface.java
@@ -95,8 +95,10 @@ public interface VisionInterface {
   }
 
   /**
-   * @param limelight The Limelight to retrieve the distance data from
-   * @return The current April Tag distance from the Limelight
+   * Gets the average distance between the specified limelight and the April Tags it sees
+   *
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
+   * @return the average distance between the robot and the April Tag(s) in meters
    */
   default double getLimelightAprilTagDistance(Limelight limelight) {
     return 0.0;
@@ -113,22 +115,30 @@ public interface VisionInterface {
   }
 
   /**
+   * Gets the pose of the robot calculated by the specified limelight via any April Tags it sees
+   *
    * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
-   * @return The current pose of the Limelight
+   * @return the pose of the robot, if the limelight can't see any April Tags, it will return 0 for
+   * x, y, and theta
    */
   default Pose2d getPoseFromAprilTags(Limelight limelight) {
     return null;
   }
 
   /**
-   * Sets the heading information of the robot, used with MT2
+   * Sets the heading and heading rate of the robot, this is used for deciding between MegaTag 1 and
+   * 2 for pose estimation.
    *
-   * @param headingDegrees The heading of the robot in degrees
-   * @param headingRateDegrees The rate of change of the heading of the robot in degrees
+   * @param headingDegrees the angle the robot is facing in degrees (0 degrees facing the red
+   * alliance)
+   * @param headingRateDegreesPerSecond the rate the robot is rotating, CCW positive
    */
-  default void setHeadingInfo(double headingDegrees, double headingRateDegrees) {}
+  default void setHeadingInfo(double headingDegrees, double headingRateDegreesPerSecond) {}
 
   /**
+   * Gets the pose calculated the last time a limelight saw an April Tag, used for resetting the
+   * robot's pose.
+   * 
    * @return The last seen pose of any Limelight that most recently saw a target
    */
   default Pose2d getLastSeenPose() {

--- a/src/main/java/frc/robot/subsystems/vision/VisionInterface.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionInterface.java
@@ -63,7 +63,10 @@ public interface VisionInterface {
   default void updateInputs(VisionInputs inputs) {}
 
   /**
-   * @param limelight The Limelight to retrieve the latency data from
+   * Gets the current latency of the Limelight in seconds. This latency is the time it takes for the
+   * Limelight to process an image and send the data to the robot.
+   * 
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    * @return The current latency of the Limelight
    */
   default double getLatencySeconds(Limelight limelight) {
@@ -71,7 +74,10 @@ public interface VisionInterface {
   }
 
   /**
-   * @param limelight The Limelight to retrieve the timestamp data from
+   * Gets the current timestamp of the Limelight in seconds. This timestamp
+   * is the time at which the data was received from the Limelight.
+   * 
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    * @return The current timestamp of the Limelight
    */
   default double getTimeStampSeconds(Limelight limelight) {
@@ -97,15 +103,17 @@ public interface VisionInterface {
   }
 
   /**
-   * @param limelight The Limelight to retrieve the data from
-   * @return The current number of April Tags of the Limelight
+   * Gets how many april tags the limelight can see.
+   * 
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
+   * @return The current number of April Tags of the limelight sees
    */
   default int getNumberOfAprilTags(Limelight limelight) {
     return 0;
   }
 
   /**
-   * @param limelight The Limelight to retrieve the pose data from
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
    * @return The current pose of the Limelight
    */
   default Pose2d getPoseFromAprilTags(Limelight limelight) {

--- a/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
@@ -1,5 +1,3 @@
-// All praise 254 lib
-
 package frc.robot.subsystems.vision;
 
 import edu.wpi.first.math.geometry.Pose2d;
@@ -9,6 +7,7 @@ import org.littletonrobotics.junction.AutoLogOutput;
 import org.littletonrobotics.junction.Logger;
 
 public class VisionSubsystem extends SubsystemBase {
+  
   private final VisionInterface visionInterface;
   private final VisionInputsAutoLogged inputs = new VisionInputsAutoLogged();
 

--- a/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
@@ -6,8 +6,17 @@ import frc.robot.subsystems.vision.VisionConstants.Limelight;
 import org.littletonrobotics.junction.AutoLogOutput;
 import org.littletonrobotics.junction.Logger;
 
+/**
+ * VisionSubsystem is a subsystem for managing vision-related tasks in the robot, including
+ * interacting with limelights, processing vision data, and logging inputs.
+ * 
+ * It provides methods for getting detailed vision information, setting heading
+ * data for pose estimation, and retrieving poses based on April Tag detection.
+ * 
+ * @author Ishan
+ */
 public class VisionSubsystem extends SubsystemBase {
-  
+
   private final VisionInterface visionInterface;
   private final VisionInputsAutoLogged inputs = new VisionInputsAutoLogged();
 
@@ -23,36 +32,83 @@ public class VisionSubsystem extends SubsystemBase {
     Logger.processInputs("Vision/", inputs);
   }
 
-  // Add methods to support DriveCommand
+  /**
+   * Gets the number of April Tags detected by a specified Limelight.
+   *
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
+   * @return The number of April Tags detected by the specified Limelight.
+   */
   public int getNumberOfAprilTags(Limelight limelight) {
     return inputs.limelightTargets[limelight.getId()];
   }
 
+  /**
+   * Gets the distance to the April Tags detected by a specified Limelight.
+   *
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
+   * @return The distance to the April Tags detected, in meters.
+   */
   public double getLimelightAprilTagDistance(Limelight limelight) {
     return inputs.limelightAprilTagDistances[limelight.getId()];
   }
 
+  /**
+   * Gets the timestamp of the last data received from a specified Limelight.
+   *
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
+   * @return The timestamp of the last data in seconds.
+   */
   public double getTimeStampSeconds(Limelight limelight) {
     return inputs.limelightTimestamps[limelight.getId()];
   }
 
+  /**
+   * Gets the latency of a specified Limelight in seconds.
+   *
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
+   * @return The latency of the Limelight in seconds.
+   */
   public double getLatencySeconds(Limelight limelight) {
     return inputs.limelightLatencies[limelight.getId()];
   }
 
+  /**
+   * Sets heading information for the robot. This information is used to assist in pose
+   * estimation by distinguishing between multiple MegaTags.
+   *
+   * @param headingDegrees The robot's heading in degrees.
+   * @param headingRateDegrees The robot's rate of rotation in degrees per second.
+   */
   public void setHeadingInfo(double headingDegrees, double headingRateDegrees) {
     visionInterface.setHeadingInfo(headingDegrees, headingRateDegrees);
   }
 
+  /**
+   * Checks if a specified Limelight can see any April Tags.
+   *
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
+   * @return True if the limelight sees any April Tags, false otherwise.
+   */
   @AutoLogOutput(key = "Vision/Has Targets")
   public boolean canSeeAprilTags(Limelight limelight) {
     return inputs.limelightSeesAprilTags[limelight.getId()];
   }
 
+  /**
+   * Gets the pose of the robot calculated from the April Tags detected by a specified Limelight.
+   *
+   * @param limelight a limelight (BACK, FRONT_LEFT, FRONT_RIGHT).
+   * @return The pose of the robot based on the detected April Tags.
+   */
   public Pose2d getPoseFromAprilTags(Limelight limelight) {
     return inputs.limelightCalculatedPoses[limelight.getId()];
   }
 
+  /**
+   * Gets the last seen pose of the robot based on the latest data from any Limelight.
+   *
+   * @return The last seen pose of the robot.
+   */
   public Pose2d getLastSeenPose() {
     return visionInterface.getLastSeenPose();
   }


### PR DESCRIPTION
This is like #11, but specific to vision.

It fixes a few bugs in `PhysicalVision`:
- ThreadManager had the wrong task given to it
- `canSeeAprilTags` had irrelevant logic in it
- `enabledPoseEstimation` was being called too many times

Additionally I just did general cleanup and commenting everywhere. We need to emphasize keeping docstrings in interfaces and not on the methods that are overriding them. Also I added fov to the limelight enum.