### PR TITLE
Command factories and triggers examples

### DIFF
--- a/src/main/java/frc/robot/commands/auto/ExampleAuto.java
+++ b/src/main/java/frc/robot/commands/auto/ExampleAuto.java
@@ -1,0 +1,21 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.auto;
+
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import frc.robot.subsystems.example.ExampleSubsystem;
+
+// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
+// information, see:
+// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
+public class ExampleAuto extends SequentialCommandGroup {
+
+  /** Creates a new ExampleAuto. */
+  public ExampleAuto(ExampleSubsystem exampleSubsystem) {
+    // Add your commands in the addCommands() call, e.g.
+    // addCommands(new FooCommand(), new BarCommand());
+    addCommands(exampleSubsystem.exampleCommand());
+  }
+}

--- a/src/main/java/frc/robot/commands/auto/ExampleAuto.java
+++ b/src/main/java/frc/robot/commands/auto/ExampleAuto.java
@@ -16,6 +16,6 @@ public class ExampleAuto extends SequentialCommandGroup {
   public ExampleAuto(ExampleSubsystem exampleSubsystem) {
     // Add your commands in the addCommands() call, e.g.
     // addCommands(new FooCommand(), new BarCommand());
-    addCommands(exampleSubsystem.exampleStartEndCommand());
+    addCommands(exampleSubsystem.setPivotToScore().alongWith(exampleSubsystem.setPivotToScore()));
   }
 }

--- a/src/main/java/frc/robot/commands/auto/ExampleAuto.java
+++ b/src/main/java/frc/robot/commands/auto/ExampleAuto.java
@@ -16,6 +16,6 @@ public class ExampleAuto extends SequentialCommandGroup {
   public ExampleAuto(ExampleSubsystem exampleSubsystem) {
     // Add your commands in the addCommands() call, e.g.
     // addCommands(new FooCommand(), new BarCommand());
-    addCommands(exampleSubsystem.exampleCommand());
+    addCommands(exampleSubsystem.exampleStartEndCommand());
   }
 }

--- a/src/main/java/frc/robot/subsystems/example/ExampleConstants.java
+++ b/src/main/java/frc/robot/subsystems/example/ExampleConstants.java
@@ -1,0 +1,5 @@
+package frc.robot.subsystems.example;
+
+public class ExampleConstants {
+  public static final double SHOOTER_PIVOT_ANGLE = 0 - 9;
+}

--- a/src/main/java/frc/robot/subsystems/example/ExampleSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/example/ExampleSubsystem.java
@@ -4,14 +4,16 @@
 
 package frc.robot.subsystems.example;
 
-import java.time.chrono.ThaiBuddhistChronology;
-
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
+import java.util.function.DoubleSupplier;
 
 public class ExampleSubsystem extends SubsystemBase {
+  private DoubleSupplier DOUBLELOL;
+
   /** Creates a new ExampleSubsystem. */
   public ExampleSubsystem() {}
 
@@ -23,57 +25,79 @@ public class ExampleSubsystem extends SubsystemBase {
     // This method will be called once per scheduler run
   }
 
-  public void exampleSubsystemFunction() {}
+  private void exampleSubsystemFunction() {}
 
-  public void setExamplePivotAngle(double angle) {
+  private void setExamplePivotAngle(double angle) {
     // normal subsystem stuff
   }
-  public double getExamplePivotAngle() {
+
+  private double getExamplePivotAngle() {
     return 0.0;
   }
- 
- 
+
+  private boolean isAngleSet() {
+    return false;
+  }
+
+  private boolean isGamepieceinRobot() {
+    return false;
+  }
+
+  // Public Command Factory
+  // create these for everything you would need to access from a command
+  // so you don't input values or acces the internals of a subsystem in the commands themselves
   public Command exampleFunctionalCommand() {
     // the command is written here instead of in it's own seperate file.
     // this saves space and makes the code more readable
-    // it's only really good for commands that use 1 subsystem though(manual override commands and
-    // such)
+
     return new FunctionalCommand(
         // does on init
         () -> this.setExamplePivotAngle(0),
         // does on execute
         () -> this.setExamplePivotAngle(1),
         // does when command ends
-        interrupted -> this.setExamplePivotAngle(0), 
+        interrupted -> this.setExamplePivotAngle(0),
         // ends the command when this is true
-        () -> getExamplePivotAngle() >= 0, 
+        () -> getExamplePivotAngle() >= 0,
         // requirements for the command
         this);
-    
-    
   }
 
-  public Command exampleStartEndCommand() {
+  // Shared internal implementation
+  private Command exampleStartEndCommand() {
     // the command is written here instead of in it's own seperate file.
     // this saves space and makes the code more readable
-    // it's only really good for commands that use 1 subsystem though(manual override commands and
-    // such)
+
     return new StartEndCommand(
-        // Sets the pivot to 1 while the command is active(runs on init())
-        () -> this.setExamplePivotAngle(1), 
-        // Sets the pivot to 0 when the command ends(runs on end())
-        () -> this.setExamplePivotAngle(0), 
+        // Sets the pivot to 1 while the command is active
+        () -> this.setExamplePivotAngle(1),
+        // Sets the pivot to 0 when the command ends
+        () -> this.setExamplePivotAngle(0),
         // requirements for the command
         this);
   }
 
-  public Command exampleRunOnceCommand() {
-    // the command is written here instead of in it's own seperate file.
-    // this saves space and makes the code more readable
-    // it's only really good for commands that use 1 subsystem though(manual override commands and
-    // such)
-
-    // runs this one time
-    return this.runOnce(() -> getExamplePivotAngle());
+  // Shared internal implementation
+  private Command exampleRunOnceCommand(double angle) {
+    return this.runOnce(() -> setExamplePivotAngle(angle));
   }
+
+  // Public Command Factory
+  public Command setPivotToScore() {
+    return exampleRunOnceCommand(ExampleConstants.SHOOTER_PIVOT_ANGLE);
+  }
+
+  // Public Command Factory
+  public Command setPivotToAngle(DoubleSupplier angle) {
+    // if you need to pass a value in do it this way
+    return exampleRunOnceCommand(angle.getAsDouble());
+  }
+
+  // this is a trigger
+  // if you need to give information from the subsystem do it like this
+  // must be a boolean
+  public final Trigger isAngleInRightSpot = new Trigger(() -> isAngleSet());
+
+  // another trigger example
+  public final Trigger hasGamepiece = new Trigger(() -> isGamepieceinRobot());
 }

--- a/src/main/java/frc/robot/subsystems/example/ExampleSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/example/ExampleSubsystem.java
@@ -4,7 +4,10 @@
 
 package frc.robot.subsystems.example;
 
+import java.time.chrono.ThaiBuddhistChronology;
+
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
@@ -25,15 +28,52 @@ public class ExampleSubsystem extends SubsystemBase {
   public void setExamplePivotAngle(double angle) {
     // normal subsystem stuff
   }
+  public double getExamplePivotAngle() {
+    return 0.0;
+  }
+ 
+ 
+  public Command exampleFunctionalCommand() {
+    // the command is written here instead of in it's own seperate file.
+    // this saves space and makes the code more readable
+    // it's only really good for commands that use 1 subsystem though(manual override commands and
+    // such)
+    return new FunctionalCommand(
+        // does on init
+        () -> this.setExamplePivotAngle(0),
+        // does on execute
+        () -> this.setExamplePivotAngle(1),
+        // does when command ends
+        interrupted -> this.setExamplePivotAngle(0), 
+        // ends the command when this is true
+        () -> getExamplePivotAngle() >= 0, 
+        // requirements for the command
+        this);
+    
+    
+  }
 
-  public Command exampleCommand() {
+  public Command exampleStartEndCommand() {
     // the command is written here instead of in it's own seperate file.
     // this saves space and makes the code more readable
     // it's only really good for commands that use 1 subsystem though(manual override commands and
     // such)
     return new StartEndCommand(
         // Sets the pivot to 1 while the command is active(runs on init())
+        () -> this.setExamplePivotAngle(1), 
         // Sets the pivot to 0 when the command ends(runs on end())
-        () -> this.setExamplePivotAngle(1), () -> this.setExamplePivotAngle(0), this);
+        () -> this.setExamplePivotAngle(0), 
+        // requirements for the command
+        this);
+  }
+
+  public Command exampleRunOnceCommand() {
+    // the command is written here instead of in it's own seperate file.
+    // this saves space and makes the code more readable
+    // it's only really good for commands that use 1 subsystem though(manual override commands and
+    // such)
+
+    // runs this one time
+    return this.runOnce(() -> getExamplePivotAngle());
   }
 }

--- a/src/main/java/frc/robot/subsystems/example/ExampleSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/example/ExampleSubsystem.java
@@ -1,0 +1,39 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems.example;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.StartEndCommand;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public class ExampleSubsystem extends SubsystemBase {
+  /** Creates a new ExampleSubsystem. */
+  public ExampleSubsystem() {}
+
+  // this is the interface for the subsystem
+  // code for motors and such would go here
+
+  @Override
+  public void periodic() {
+    // This method will be called once per scheduler run
+  }
+
+  public void exampleSubsystemFunction() {}
+
+  public void setExamplePivotAngle(double angle) {
+    // normal subsystem stuff
+  }
+
+  public Command exampleCommand() {
+    // the command is written here instead of in it's own seperate file.
+    // this saves space and makes the code more readable
+    // it's only really good for commands that use 1 subsystem though(manual override commands and
+    // such)
+    return new StartEndCommand(
+        // Sets the pivot to 1 while the command is active(runs on init())
+        // Sets the pivot to 0 when the command ends(runs on end())
+        () -> this.setExamplePivotAngle(1), () -> this.setExamplePivotAngle(0), this);
+  }
+}


### PR DESCRIPTION
command factories are subsystem-specific commands at are written in the subsystems in order to reduce the amount of information shared between the subsystem and other parts of code. Triggers are basically the same thing but as booleans, meaning we can get information from the subsystem using them; we can also bind commands to them so when they happen a command is scheduled. Pretty cool stuff that should make the code much more readable and reduce the amount of complex commands we have, when used in combination with the .alongWith() and .and().